### PR TITLE
do not add MenuButton to ButtonBox

### DIFF
--- a/src/LdapPopup.rb
+++ b/src/LdapPopup.rb
@@ -369,11 +369,13 @@ module Yast
                 PushButton(Id(:cancel), Opt(:key_F9), Label.CancelButton),
                 PushButton(Id(:help), Opt(:key_F2), Label.HelpButton)
               ) :
-              ButtonBox(
-                PushButton(Id(:ok), Opt(:default, :key_F10), Label.OKButton),
-                PushButton(Id(:cancel), Opt(:key_F9), Label.CancelButton),
-                PushButton(Id(:help), Opt(:key_F2), Label.HelpButton),
-                add_button
+              HBox(
+                add_button,
+                ButtonBox(
+                  PushButton(Id(:ok), Opt(:default, :key_F10), Label.OKButton),
+                  PushButton(Id(:cancel), Opt(:key_F9), Label.CancelButton),
+                  PushButton(Id(:help), Opt(:key_F2), Label.HelpButton)
+                )
               )
           ),
           HSpacing(1)


### PR DESCRIPTION
ButtonBox only accepts PushButtons, trying to add a MenuButton results
in crash. Instead, put the ButtonBox and the MenuButton in a HBox.
See bnc#881798 for details.

Signed-off-by: Stefan Brüns stefan.bruens@rwth-aachen.de
