### PR TITLE
Install required package in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM yastdevel/cpp:sle12-sp5
 
 
 RUN zypper --gpg-auto-import-keys --non-interactive in --no-recommends \
-  libldapcpp-devel
+  libldapcpp-devel \
+  yast2-perl-bindings
 COPY . /usr/src/app
 


### PR DESCRIPTION
## Problem

Travis [is not happy](https://travis-ci.org/yast/yast-ldap/builds/560976597) because it was not able to provide the required `YaST::YCP` perl module. 

```
Can't locate YaST/YCP.pm in @INC (you may need to install the YaST::YCP module)
```
## Solution

To update the `Dockerfile`, adding the `yast2-perl-bindings` to be installed, since it

> provides the `YCP.pm` file, used by the `LdapServerAccess` Perl module.