### PR TITLE
Fix LDAP connection

### DIFF
--- a/package/yast2-ldap.changes
+++ b/package/yast2-ldap.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 21 10:29:52 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Use the given BindDN to connect to the LDAP database.
+- bsc#1185054
+- 4.4.1
+
+-------------------------------------------------------------------
 Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - 4.4.0

--- a/package/yast2-ldap.spec
+++ b/package/yast2-ldap.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ldap
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/Ldap.rb
+++ b/src/Ldap.rb
@@ -436,6 +436,10 @@ module Yast
     # Reads LDAP settings from the SCR
     # @return success
     def Read
+      # Settings are read only if they were not read before. Anyway, reading settings can be forced if
+      # needed:
+      #   Ldap.SetReadSettings(true)
+      #   Ldap.Read
       return true unless @read_settings
 
       @start          = Nsswitch.ReadDb("passwd").include?("sss")

--- a/src/Ldap.rb
+++ b/src/Ldap.rb
@@ -436,6 +436,7 @@ module Yast
     # Reads LDAP settings from the SCR
     # @return success
     def Read
+      return true unless @read_settings
 
       @start          = Nsswitch.ReadDb("passwd").include?("sss")
       @server         = ReadLdapHosts()
@@ -446,6 +447,8 @@ module Yast
       @base_config_dn = "ou=ldapconfig," + @base_dn
 
       Builtins.y2milestone("Read LDAP Settings: server %1, base_dn %2, bind_dn %3, base_config_dn %4",@server, @base_dn, @bind_dn, @base_config_dn)
+
+      @read_settings = false
 
       true
     end


### PR DESCRIPTION
## Problem

When connecting to a LDAP database, the given BindDN is ignored and the default proposed BindDN is always used.

https://bugzilla.suse.com/show_bug.cgi?id=1185054


## Solution

The given BindDN was overwritten when re-reading the system settings. The issue is gone by avoiding to read the system settings if they were already read.

Note: the proposed solution makes use of the existing `@read_settings` attribute. Currently, that attribute was not used at all, but it was added in SLE9 times in order to fix the very same problem when adding a new LDAP user with YaPI, see https://bugzilla.suse.com/show_bug.cgi?id=60898. 


## Testing

* Manually tested.

### How to Test

*yast2-users* reads the LDAP settings from */etc/openldap/ldap.conf*. As commented [here](https://github.com/yast/yast-users-ng/blob/master/doc/auth-modules.md#the-yast-auth-server-package), previous versions of *yast2-auth-server* had an option to generate that file in order to make other YaST modules to work. But that is not the case any more.

Note: that issue with the LDAP settings location is not fixed yet, and it is out of the scope of this PR. Therefore, some manual configuration is required to test the BindDN fix:

* Configure a new LDAP server: *yast2 ldap-server* (you can simply use the proposed values).
* Copy this configuration to */etc/openldap/ldap.conf*:

~~~
URI ldap://localhost:389
BASE dc=example,dc=net
TLS_REQCERT never
~~~ 

In *yast2-users*, you need to enter this BindDN to connect to the LDAP database: *cn=Directory Manager*.
